### PR TITLE
Fix image paste to work with system screenshot tools

### DIFF
--- a/src/ImageDrop.js
+++ b/src/ImageDrop.js
@@ -44,18 +44,10 @@ export class ImageDrop {
 	 * @param {Event} evt
 	 */
 	handlePaste(evt) {
+		evt.preventDefault();
 		if (evt.clipboardData && evt.clipboardData.items && evt.clipboardData.items.length) {
 			this.readFiles(evt.clipboardData.items, dataUrl => {
-				const selection = this.quill.getSelection();
-				if (selection) {
-					// we must be in a browser that supports pasting (like Firefox)
-					// so it has already been placed into the editor
-				}
-				else {
-					// otherwise we wait until after the paste when this.quill.getSelection()
-					// will return a valid index
-					setTimeout(() => this.insert(dataUrl), 0);
-				}
+				setTimeout(() => this.insert(dataUrl), 0);
 			});
 		}
 	}


### PR DESCRIPTION
The image paste function was not working when pasting through the system-installed screenshot tools such as Lightshot, Grab (Mac), Gyazo.